### PR TITLE
Update all links to use react-router-dom instead of href.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Music Markdown</title>
   </head>
   <body>
     <noscript>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,16 +4,17 @@ import MarkdownMusicSourceFetcher from './MarkdownMusicSourceFetcher';
 import ResponsiveContainer from './ResponsiveContainer.js';
 import Sandbox from './Sandbox.js';
 import './App.scss';
-import '../../node_modules/bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
 import MusicMarkdownNavbar from './MusicMarkdownNavbar.js';
 
 const App = () => (
-  <ResponsiveContainer children={[MusicMarkdownNavbar(), HomeRouter()]} />
+  <ResponsiveContainer children={[HomeRouter()]} />
 );
 
 const HomeRouter = () => (
   <Router key="home-router">
     <div>
+      <Route component={MusicMarkdownNavbar} />
       <Route exact path="/" component={Navigation} />
       <Route path="/sandbox" component={Sandbox} />
       <Route path="/repos/:owner/:repo/contents/:path" component={MarkdownMusicSourceFetcher} />

--- a/src/components/MusicMarkdownNavbar.js
+++ b/src/components/MusicMarkdownNavbar.js
@@ -2,6 +2,7 @@ import Navbar from 'react-bootstrap/Navbar';
 import NavDropdown from 'react-bootstrap/NavDropdown';
 import Nav from 'react-bootstrap/Nav';
 import React from 'react';
+import { NavLink } from 'react-router-dom';
 import { getRepositories, addRepository } from '../util/GithubRepositoryUtil';
 import { REPOS_LOCAL_STORAGE_KEY } from '../util/Constants';
 
@@ -20,7 +21,7 @@ const MusicMarkdownNavbar = () => {
       <Navbar.Collapse>
         <Nav className="mr-auto">
           <RepositoriesNavDropodown />
-          <Nav.Link href="#/sandbox">Sandbox (Beta)</Nav.Link>
+          <NavLink to="/sandbox" className="nav-link" activeClassName="active">Sandbox (Beta)</NavLink>
         </Nav>
       </Navbar.Collapse>
     </Navbar>
@@ -38,11 +39,11 @@ const RepositoriesNavDropodown = () => {
     repoList.forEach(function(repo) {
       const repoId = `${repo.owner}/${repo.repo}${repo.path}`;
       // TODO: List valid files after clicking on repo name
-      const itemHref = `#/repos/${repo.owner}/${repo.repo}/contents${repo.path}`;
+      const itemHref = `/repos/${repo.owner}/${repo.repo}/contents${repo.path}`;
       repoDropdownItems.push(
-        <NavDropdown.Item href={itemHref} key={`dropdown-item-${repoId}`}>
+        <NavLink to={itemHref} key={`dropdown-item-${repoId}`} className="dropdown-item">
           {repoId}
-        </NavDropdown.Item>);
+        </NavLink>);
     });
   }
   return (

--- a/src/components/ResponsiveContainer.js
+++ b/src/components/ResponsiveContainer.js
@@ -1,4 +1,4 @@
-import Container from '../../node_modules/react-bootstrap/Container.js';
+import Container from 'react-bootstrap/Container.js';
 import React from 'react';
 
 const RESPONSIVE_CONTAINER_KEY = 'app-container';


### PR DESCRIPTION
- Shift all link components to use `react-router-dom`. This enables us to switch between `HashRouter` and `BrowserRouter` easily.
- Added `MusicMarkdownNavbar` within the router so that all links are children of a router.
- Simplified import paths.