### PR TITLE
Get width of Markdown container

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2440,6 +2440,11 @@
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
     },
+    "batch-processor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
+      "integrity": "sha1-dclcMrdI4IUNEMKxaPa9vpiRrOg="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -4799,6 +4804,14 @@
       "version": "1.3.113",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz",
       "integrity": "sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g=="
+    },
+    "element-resize-detector": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/element-resize-detector/-/element-resize-detector-1.1.15.tgz",
+      "integrity": "sha512-16/5avDegXlUxytGgaumhjyQoM6hpp5j3+L79sYq5hlXfTNRy5WMMuTVWkZU3egp/CokCmTmvf18P3KeB57Iog==",
+      "requires": {
+        "batch-processor": "^1.0.0"
+      }
     },
     "elliptic": {
       "version": "6.4.1",
@@ -16208,6 +16221,16 @@
         "react-transition-group": "^2.5.1",
         "uncontrollable": "^6.0.0",
         "warning": "^4.0.1"
+      }
+    },
+    "react-container-dimensions": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/react-container-dimensions/-/react-container-dimensions-1.4.1.tgz",
+      "integrity": "sha512-f5WXYpsL0vAuT9hD6bSTqRYOJXFbU9JzjSZfscNT77PbdCUReLv2/aSvYBgkXyALtOBVdS/nwO5RVZgBxxWDnw==",
+      "requires": {
+        "element-resize-detector": "^1.1.10",
+        "invariant": "^2.2.2",
+        "prop-types": "^15.5.8"
       }
     },
     "react-context-toolbox": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "query-string": "^6.2.0",
     "react": "^16.8.1",
     "react-bootstrap": "^1.0.0-beta.5",
+    "react-container-dimensions": "^1.4.1",
     "react-dom": "^16.8.1",
     "react-router-dom": "^4.3.1",
     "react-scripts": "^2.1.8"

--- a/src/components/MarkdownMusic.js
+++ b/src/components/MarkdownMusic.js
@@ -1,9 +1,10 @@
+import ContainerDimensions from 'react-container-dimensions';
 import React from 'react';
 import MarkdownIt from 'markdown-it';
 import MarkdownItMusic from 'markdown-it-music';
 import { YouTubeToggle } from './YouTube';
 
-class MarkdownMusic extends React.Component {
+class MarkdownMusicRender extends React.Component {
   constructor(props) {
     super(props);
 
@@ -13,6 +14,7 @@ class MarkdownMusic extends React.Component {
 
   render() {
     this.md.setTranspose(this.props.transpose);
+    this.md.setMaxWidth(this.props.width);
     const html = this.md.render(this.props.source);
 
     return (
@@ -23,5 +25,11 @@ class MarkdownMusic extends React.Component {
     );
   }
 }
+
+const MarkdownMusic = ({ source, transpose }) => (
+  <ContainerDimensions>
+    <MarkdownMusicRender source={source} transpose={transpose} />
+  </ContainerDimensions>
+);
 
 export default MarkdownMusic;


### PR DESCRIPTION
This PR wraps the Markdown Renderer with a React component that measures the container width. This information is passed to the markdown renderer to provide responsive resizing.