### PR TITLE
React router cleanup allowing multiple path particles

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { HashRouter as Router, Route, Switch } from 'react-router-dom';
+import { HashRouter as Router, Route } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import store from '../redux/store';
 
@@ -22,16 +22,12 @@ const HomeRouter = () => (
       <div>
         <Route component={MusicMarkdownNavbar} />
         <Route exact path="/" component={Navigation} />
-        <Route path='/sandbox' component={Sandbox} />
-        <Route path='/render' component={MarkdownMusicSourceFetcher} />
-        <Switch>
-          <Route path='/repos/:owner/:repo/:view(browser)/:branch/:path' component={RepositoryNavigation}></Route>
-          <Route path='/repos/:owner/:repo/:view(viewer)/:branch/:path' component={MarkdownMusicSourceFetcher}></Route>
-          {/* TODO: Add editor component */}
-          <Route path='/repos/:owner/:repo/:view(editor)/:branch/:path' component={Sandbox}></Route>
-          <Route path='/repos/:owner/:repo/:view(browser)/:branch' component={RepositoryNavigation}></Route>
-          <Route path='/repos/:owner/:repo' component={BranchNavigation}></Route>
-        </Switch>
+        <Route excat path='/sandbox' component={Sandbox} />
+        <Route exact path='/repos/:owner/:repo' component={BranchNavigation} />
+        <Route exact path='/repos/:owner/:repo/:view(viewer)/:branch/:path+' component={MarkdownMusicSourceFetcher} />
+        <Route exact path='/repos/:owner/:repo/:view(browser)/:branch/:path*' component={RepositoryNavigation} />
+        {/* TODO: Add editor component */}
+        <Route exact path='/repos/:owner/:repo/:view(editor)/:branch/:path+' component={Sandbox} />
       </div>
     </Router>
   </Provider>

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -12,7 +12,7 @@ const Breadcrumbs = ({ pathname }) => {
   const viewNames = ['browser', 'viewer', 'editor'];
   const keyBase = 'breadcrumb-item-';
 
-  const subDirectoriesArr = decodeURIComponent(pathname).split('/');
+  const subDirectoriesArr = pathname.split('/');
 
   // pathname starts with '/', so discard. Pathname will sometimes end with '/', so discard that as well.
   subDirectoriesArr.shift();


### PR DESCRIPTION
This PR prevents us from having to URI encode the path fragments, which makes our URL cleaner and easier to read.

I also removed the switch statement, which we can put back if we want, but I preferred it without the switch statement, because if we design our URLs correctly, then they should be mutually exclusive out of the box.

Fixes #62 