### PR TITLE
Toolbar - Material-UI migration.

### DIFF
--- a/src/components/MarkdownMusicSourceFetcher.js
+++ b/src/components/MarkdownMusicSourceFetcher.js
@@ -3,7 +3,6 @@ import queryString from 'query-string';
 import { connect } from 'react-redux';
 
 import MarkdownMusic from './MarkdownMusic';
-import Toolbar from './Toolbar';
 import { getContents } from '../lib/github';
 import { setTranspose, setColumnCount, setFontSize } from '../redux/actions';
 
@@ -46,7 +45,6 @@ class MarkdownMusicSourceFetcher extends React.Component {
     } else {
       return (
         <div className="Markdown">
-          <Toolbar></Toolbar>
           <MarkdownMusic source={markdown} />
         </div>
       );

--- a/src/components/MusicMarkdownNavbar.js
+++ b/src/components/MusicMarkdownNavbar.js
@@ -1,43 +1,82 @@
-import AppBar from '@material-ui/core/AppBar';
-import Toolbar from '@material-ui/core/Toolbar';
-import Typography from '@material-ui/core/Typography';
-import Button from '@material-ui/core/Button';
-import Menu from '@material-ui/core/Menu';
-import MenuItem from '@material-ui/core/MenuItem';
-import { withStyles } from '@material-ui/core/styles';
-
 import React from 'react';
 import { NavLink, Link } from 'react-router-dom';
+
+import AppBar from '@material-ui/core/AppBar';
+import Button from '@material-ui/core/Button';
+import Divider from '@material-ui/core/Divider';
+import Drawer from '@material-ui/core/Drawer';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import Toolbar from '@material-ui/core/Toolbar';
+import Typography from '@material-ui/core/Typography';
+import { withStyles } from '@material-ui/core/styles';
+
 import { getRepositories, addRepository } from '../lib/github';
 import { REPOS_LOCAL_STORAGE_KEY } from '../lib/constants';
+import MusicToolbar from './MusicToolbar';
 
 const styles = (theme) => ({
-  reactRouterHoverInherit: theme.reactRouterHoverInherit
+  reactRouterHoverInherit: theme.reactRouterHoverInherit,
+  grow: {
+    flexGrow: 1
+  }
 });
 
-const MusicMarkdownNavbar = (props) => {
-  const { classes } = props;
+class MusicMarkdownNavbar extends React.Component {
+  constructor(props) {
+    super(props);
 
-  if (!localStorage.getItem(REPOS_LOCAL_STORAGE_KEY)) {
-    // TODO: sanitize this input when storing
-    addRepository('music-markdown', 'almost-in-time', '/', 'master');
+    this.state = {
+      open: false
+    };
+
+    this.handleDrawerClose = this.handleDrawerClose.bind(this);
+    this.handleDrawerOpen = this.handleDrawerOpen.bind(this);
   }
 
-  return (
-    <AppBar position={'sticky'} key='top-navbar'>
-      <Toolbar>
-        <Button className={classes.reactRouterHoverInherit} component={Link} to='/'>
-          <Typography variant='h6'>
-            Music Markdown
-          </Typography>
-        </Button>
-        <RepositoriesNavDropdown {...props} />
-        <Button className={classes.reactRouterHoverInherit} component={NavLink} to='/sandbox'>
-          Sandbox
-        </Button>
-      </Toolbar>
-    </AppBar>
-  );
+  handleDrawerOpen() {
+    this.setState({ open: !this.state.open });
+  };
+
+  handleDrawerClose() {
+    this.setState({ open: false });
+  };
+
+  render() {
+    const { classes } = this.props;
+    const { open } = this.state;
+
+    if (!localStorage.getItem(REPOS_LOCAL_STORAGE_KEY)) {
+      // TODO: sanitize this input when storing
+      addRepository('music-markdown', 'almost-in-time', '/', 'master');
+    }
+
+    return (
+      <>
+        <AppBar position={'sticky'} key='top-navbar'>
+          <Toolbar>
+            <Button className={classes.reactRouterHoverInherit} component={Link} to='/'>
+              <Typography variant='h6'>
+                Music Markdown
+              </Typography>
+            </Button>
+            <RepositoriesNavDropdown {...this.props} />
+            <Button className={classes.reactRouterHoverInherit} component={NavLink} to='/sandbox'>
+              Sandbox
+            </Button>
+            <div className={classes.grow} />
+            <Button onClick={this.handleDrawerOpen}>
+              Toolbar
+            </Button>
+          </Toolbar>
+        </AppBar>
+        <Drawer open={open} variant={'persistent'} anchor={'bottom'}>
+          <Divider />
+          <MusicToolbar></MusicToolbar>
+        </Drawer>
+      </>
+    );
+  }
 };
 
 /**

--- a/src/components/MusicToolbar.js
+++ b/src/components/MusicToolbar.js
@@ -1,14 +1,15 @@
 import React from 'react';
-import ButtonToolbar from 'react-bootstrap/ButtonToolbar';
-import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import Button from 'react-bootstrap/Button';
+import Grid from '@material-ui/core/Grid';
+import Toolbar from '@material-ui/core/Toolbar';
+import Typography from '@material-ui/core/Typography';
 import { connect } from 'react-redux';
 
 import { transpose } from '../redux/actions';
 import { updateColumnCount } from '../redux/actions';
 import { updateFontSize } from '../redux/actions';
 
-class Toolbar extends React.Component {
+class MusicToolbar extends React.Component {
   constructor(props) {
     super(props);
 
@@ -38,23 +39,29 @@ class Toolbar extends React.Component {
   render() {
     // TODO: Move dark theme to redux store.
     return (
-      <ButtonToolbar className='border justify-content-center bg-dark'>
-        <span className='padding bg-dark text-light my-auto'>Transpose</span>
-        <ButtonGroup>
-          <Button variant='dark' onClick={this.handleTransposeClick}>{this.decrease}</Button>
-          <Button variant='dark' onClick={this.handleTransposeClick}>{this.increase}</Button>
-        </ButtonGroup>
-        <span className='padding bg-dark text-light my-auto'>Columns</span>
-        <ButtonGroup>
-          <Button variant='dark' onClick={this.handleColumnClick}>{this.decrease}</Button>
-          <Button variant='dark' onClick={this.handleColumnClick}>{this.increase}</Button>
-        </ButtonGroup>
-        <span className='padding bg-dark text-light my-auto'>Font Size</span>
-        <ButtonGroup>
-          <Button variant='dark' onClick={this.handleFontClick}>{this.decrease}</Button>
-          <Button variant='dark' onClick={this.handleFontClick}>{this.increase}</Button>
-        </ButtonGroup>
-      </ButtonToolbar>
+      <Toolbar>
+        <Grid container direction='row' justify='center' alignItems='center' spacing={16}>
+          {[{ name: 'Transpose', clickCallback: this.handleTransposeClick },
+            { name: 'Column Count', clickCallback: this.handleColumnClick },
+            { name: 'Font Size', clickCallback: this.handleFontClick }].map(({ name, clickCallback }) => (
+            <React.Fragment key={name}>
+              <Grid item>
+                <Typography variant='h6'>{name}</Typography>
+              </Grid>
+              <Grid item>
+                <Button onClick={clickCallback}>
+                  <Typography>{this.decrease}</Typography>
+                </Button>
+              </Grid>
+              <Grid item>
+                <Button onClick={clickCallback}>
+                  <Typography>{this.increase}</Typography>
+                </Button>
+              </Grid>
+            </React.Fragment>
+          ))}
+        </Grid>
+      </Toolbar>
     );
   }
 }
@@ -62,4 +69,4 @@ class Toolbar extends React.Component {
 export default connect(
   undefined,
   { transpose, updateColumnCount, updateFontSize }
-)(Toolbar);
+)(MusicToolbar);

--- a/src/components/MusicToolbar.js
+++ b/src/components/MusicToolbar.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Button from 'react-bootstrap/Button';
+import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';

--- a/src/components/MusicToolbar.spec.js
+++ b/src/components/MusicToolbar.spec.js
@@ -3,15 +3,15 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import store from '../redux/store';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
-import Toolbar from './Toolbar';
+import MusicToolbar from './MusicToolbar';
 
-describe('Toolbar', () => {
+describe('MusicToolbar', () => {
   it('renders without crashing', () => {
     const div = document.createElement('div');
     ReactDOM.render(
       <Provider store={store}>
         <Router>
-          <Route path='/' exact component={Toolbar} />
+          <Route path='/' exact component={MusicToolbar} />
         </Router>
       </Provider>, div);
     ReactDOM.unmountComponentAtNode(div);

--- a/src/components/Sandbox.js
+++ b/src/components/Sandbox.js
@@ -3,12 +3,9 @@ import MarkdownMusic from './MarkdownMusic';
 import { parseVoicing } from 'markdown-it-music/lib/voicing';
 import { renderChordDiagram } from 'markdown-it-music/renderers/chord_diagram';
 import { guitarChordLibrary } from 'markdown-it-music/renderers/chord_library';
-import Toolbar from './Toolbar';
 
 const Sandbox = () => (
   <div>
-    <Toolbar></Toolbar>
-
     <h1>Music Markdown Sandbox</h1>
     <p>
       This page exercises various subcomponents of music-markdown and


### PR DESCRIPTION
Migrate the Toolbar (renamed to `MusicToolbar`) to Material-UI.

![toolbar-migration](https://user-images.githubusercontent.com/5377267/54765326-87716f00-4bb6-11e9-988c-aacecfd25523.gif)
