### PR TITLE
Overhaul of GitHub repository configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,21 +2,23 @@
   "extends": "google",
   "parser": "babel-eslint",
   "rules": {
-      "linebreak-style": 0,
-      "require-jsdoc": 0,
-      "comma-dangle": 0,
-      "max-len": [2, {
-        "code": 120,
-        "tabWidth": 2,
-        "ignoreUrls": true
-      }],
-      "indent": ["error", 2, {
-          "MemberExpression": 1
-      }],
-      "object-curly-spacing": ["error", "always"],
-      "react/jsx-uses-react": "error",
-      "react/jsx-uses-vars": "error" ,
-      "new-cap": 0
+    "linebreak-style": 0,
+    "require-jsdoc": 0,
+    "comma-dangle": 0,
+    "max-len": [2, {
+      "code": 120,
+      "tabWidth": 2,
+      "ignoreUrls": true
+    }],
+    "indent": ["error", 2, {
+        "MemberExpression": 1
+    }],
+    "object-curly-spacing": ["error", "always"],
+    "react/jsx-uses-react": "error",
+    "react/jsx-uses-vars": "error" ,
+    "new-cap": 0,
+    "no-invalid-this": 0,
+    "babel/no-invalid-this": 1
   },
-  "plugins": ["react"]
+  "plugins": ["react", "babel"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1449,7 +1449,7 @@
       "resolved": "https://registry.npmjs.org/abcjs/-/abcjs-5.6.7.tgz",
       "integrity": "sha512-P0kDNhmB/gmvQuoR7pUH2bcCi4Bj94J9wnkmvuOl8NJQOUmGmMsgdiODESREDmQ26axIELYtfUnjumC7Eu20tQ==",
       "requires": {
-        "midi": "git+https://github.com/paulrosen/MIDI.js.git#e593ffef81a0350f99448e3ab8111957145ff6b2"
+        "midi": "git+https://github.com/paulrosen/MIDI.js.git#abcjs"
       }
     },
     "accepts": {
@@ -3300,7 +3300,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3665,7 +3666,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3713,6 +3715,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3751,11 +3754,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -4258,6 +4263,30 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-fetch": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz",
+      "integrity": "sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.1.2",
+        "whatwg-fetch": "2.0.4"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
+          "dev": true
+        },
+        "whatwg-fetch": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+          "dev": true
+        }
       }
     },
     "cross-spawn": {
@@ -5827,6 +5856,15 @@
         }
       }
     },
+    "eslint-plugin-babel": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-5.3.0.tgz",
+      "integrity": "sha512-HPuNzSPE75O+SnxHIafbW5QB45r2w78fxqwK3HmjqIUoPfPzVrq6rD+CINU3yzoDSzEhUkX07VUphbF73Lth/w==",
+      "dev": true,
+      "requires": {
+        "eslint-rule-composer": "^0.3.0"
+      }
+    },
     "eslint-plugin-flowtype": {
       "version": "2.50.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.50.1.tgz",
@@ -5962,6 +6000,12 @@
         "prop-types": "^15.6.2",
         "resolve": "^1.9.0"
       }
+    },
+    "eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "3.7.1",
@@ -7169,7 +7213,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7187,11 +7232,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7204,15 +7251,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7315,7 +7365,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7325,6 +7376,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7337,17 +7389,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -7364,6 +7419,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7436,7 +7492,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7446,6 +7503,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7521,7 +7579,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7551,6 +7610,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7568,6 +7628,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7606,11 +7667,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -9625,6 +9688,16 @@
       "requires": {
         "jest-mock": "^23.2.0",
         "jest-util": "^23.4.0"
+      }
+    },
+    "jest-fetch-mock": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-2.1.1.tgz",
+      "integrity": "sha512-/E0I80zMRTTExfM7QQZsqizT31EMHCBnqACERd2QR+7riSgta3OcHF3RzakukzQ4o3oEyIi6OleB3PAU6ArgDg==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^2.2.2",
+        "promise-polyfill": "^7.1.1"
       }
     },
     "jest-get-type": {
@@ -19190,6 +19263,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+    },
+    "promise-polyfill": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-7.1.2.tgz",
+      "integrity": "sha512-FuEc12/eKqqoRYIGBrUptCBRhobL19PS2U31vMNTfyck1FxPyMfgsXyW4Mav85y/ZN1hop3hOwRlUDok23oYfQ==",
+      "dev": true
     },
     "prompts": {
       "version": "0.1.14",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.11.2",
     "eslint-config-google": "^0.12.0",
+    "eslint-plugin-babel": "^5.3.0",
+    "jest-fetch-mock": "^2.1.1",
     "redux-devtools": "^3.5.0"
   }
 }

--- a/src/components/AddRepository.js
+++ b/src/components/AddRepository.js
@@ -1,0 +1,164 @@
+import React from 'react';
+import classNames from 'classnames';
+import Add from '@material-ui/icons/Add';
+import CloseIcon from '@material-ui/icons/Close';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogActions from '@material-ui/core/DialogActions';
+import ErrorIcon from '@material-ui/icons/Error';
+import Grid from '@material-ui/core/Grid';
+import IconButton from '@material-ui/core/IconButton';
+import TextField from '@material-ui/core/TextField';
+import Snackbar from '@material-ui/core/Snackbar';
+import SnackbarContent from '@material-ui/core/SnackbarContent';
+import { withStyles } from '@material-ui/core/styles';
+
+
+const styles2 = (theme) => ({
+  error: {
+    backgroundColor: theme.palette.error.dark,
+  },
+  icon: {
+    fontSize: 20,
+  },
+  iconVariant: {
+    opacity: 0.9,
+    marginRight: theme.spacing.unit,
+  },
+  message: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  margin: {
+    margin: theme.spacing.unit,
+  },
+});
+
+const ErrorSnackbar = (props) => (
+  <Snackbar anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+    open={props.open} autoHideDuration={6000} onClose={props.handleClose}>
+    <SnackbarContent
+      className={props.classes.error}
+      aria-describedby="client-snackbar"
+      message={
+        <span id="client-snackbar" className={props.classes.message}>
+          <ErrorIcon className={classNames(props.classes.icon, props.classes.iconVariant)} />
+          {props.message}
+        </span>
+      }
+      action={[
+        <IconButton
+          key="close"
+          aria-label="Close"
+          color="inherit"
+          className={props.classes.close}
+          onClick={props.handleClose}
+        >
+          <CloseIcon className={props.classes.icon} />
+        </IconButton>,
+      ]}
+    />
+  </Snackbar>
+);
+
+const StyledErrorSnackbar = withStyles(styles2)(ErrorSnackbar);
+
+
+class AddRepository extends React.Component {
+  state = {
+    open: false,
+    name: '',
+    owner: '',
+    message: null,
+    error: false
+  };
+
+  handleDialogOpen = () => {
+    this.setState({ open: true });
+  }
+
+  handleDialogClose = () => {
+    this.setState({
+      open: false,
+      name: '',
+      owner: '',
+      error: false
+    });
+  }
+
+  handleShowError = (message) => {
+    this.setState({
+      message: message,
+      error: true
+    });
+  }
+
+  handleClearError = (event, reason) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+    this.setState({ error: false });
+  }
+
+  handleDialogAdd = async () => {
+    try {
+      await this.props.handleAddRepository(`${this.state.owner}/${this.state.name}`);
+      this.handleDialogClose();
+    } catch (err) {
+      this.handleShowError(err.message);
+    }
+  }
+
+  handleUpdateOwner = (event) => {
+    this.setState({ owner: event.target.value });
+  }
+
+  handleUpdateName = (event) => {
+    this.setState({ name: event.target.value });
+  }
+
+  // TODO: style to add margin on right.
+  render = () => (
+    <>
+      <Grid container direction='row' justify='flex-end' alignItems='flex-end'>
+        <IconButton aria-label='Add' onClick={this.handleDialogOpen}>
+          <Add />
+        </IconButton>
+        <Dialog open={this.state.open} aria-labelledby='add-repository-dialog'>
+          <DialogTitle id='add-repository-dialog-title'>Add Repository</DialogTitle>
+          <DialogContent>
+            <TextField
+              autoFocus
+              margin='dense'
+              id='owner'
+              label='Repository Owner'
+              value={this.state.owner}
+              onChange={(e) => this.handleUpdateOwner(e)}
+              fullWidth
+            />
+            <TextField
+              margin='dense'
+              id='name'
+              label='Repository Name'
+              value={this.state.name}
+              onChange={(e) => this.handleUpdateName(e)}
+              fullWidth
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={this.handleDialogClose}>Cancel</Button>
+            <Button onClick={this.handleDialogAdd}>Add</Button>
+          </DialogActions>
+        </Dialog>
+      </Grid>
+      <StyledErrorSnackbar
+        message={this.state.message}
+        open={this.state.error}
+        handleClose={this.handleClearError} />
+    </>
+  );
+}
+
+export default AddRepository;

--- a/src/components/AddRepository.js
+++ b/src/components/AddRepository.js
@@ -16,7 +16,7 @@ import SnackbarContent from '@material-ui/core/SnackbarContent';
 import { withStyles } from '@material-ui/core/styles';
 
 
-const styles2 = (theme) => ({
+const styles = (theme) => ({
   error: {
     backgroundColor: theme.palette.error.dark,
   },
@@ -36,16 +36,16 @@ const styles2 = (theme) => ({
   },
 });
 
-const ErrorSnackbar = (props) => (
+const ErrorSnackbar = ({ open, handleClose, classes, message }) => (
   <Snackbar anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-    open={props.open} autoHideDuration={6000} onClose={props.handleClose}>
+    open={open} autoHideDuration={6000} onClose={handleClose}>
     <SnackbarContent
-      className={props.classes.error}
+      className={classes.error}
       aria-describedby="client-snackbar"
       message={
-        <span id="client-snackbar" className={props.classes.message}>
-          <ErrorIcon className={classNames(props.classes.icon, props.classes.iconVariant)} />
-          {props.message}
+        <span id="client-snackbar" className={classes.message}>
+          <ErrorIcon className={classNames(classes.icon, classes.iconVariant)} />
+          {message}
         </span>
       }
       action={[
@@ -53,17 +53,17 @@ const ErrorSnackbar = (props) => (
           key="close"
           aria-label="Close"
           color="inherit"
-          className={props.classes.close}
-          onClick={props.handleClose}
+          className={classes.close}
+          onClick={handleClose}
         >
-          <CloseIcon className={props.classes.icon} />
+          <CloseIcon className={classes.icon} />
         </IconButton>,
       ]}
     />
   </Snackbar>
 );
 
-const StyledErrorSnackbar = withStyles(styles2)(ErrorSnackbar);
+const StyledErrorSnackbar = withStyles(styles)(ErrorSnackbar);
 
 
 class AddRepository extends React.Component {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -9,11 +9,14 @@ import createMuiTheme from '@material-ui/core/styles/createMuiTheme';
 import MarkdownMusicSourceFetcher from './MarkdownMusicSourceFetcher';
 import MusicMarkdownNavbar from './MusicMarkdownNavbar';
 import ResponsiveContainer from './ResponsiveContainer';
+import RepositoryEditor from './RepositoryEditor';
 import RepositoryNavigation from './RepositoryNavigation';
 import BranchNavigation from './BranchNavigation';
 import Sandbox from './Sandbox.js';
 import store from '../redux/store';
 import './App.scss';
+
+const REPO_REGEX = '/repos/:repo([^/]+/[^/]+)';
 
 // TODO: Build button toggle for dark/light
 const theme = createMuiTheme({
@@ -44,11 +47,12 @@ const HomeRouter = () => (
         <Route component={MusicMarkdownNavbar} />
         <Route exact path="/" component={Navigation} />
         <Route excat path='/sandbox' component={Sandbox} />
-        <Route exact path='/repos/:owner/:repo' component={BranchNavigation} />
-        <Route exact path='/repos/:owner/:repo/:view(viewer)/:branch/:path+' component={MarkdownMusicSourceFetcher} />
-        <Route exact path='/repos/:owner/:repo/:view(browser)/:branch/:path*' component={RepositoryNavigation} />
+        <Route exact path='/repos' component={RepositoryEditor} />
+        <Route exact path={REPO_REGEX} component={BranchNavigation} />
+        <Route exact path={`${REPO_REGEX}/:view(viewer)/:branch/:path+`} component={MarkdownMusicSourceFetcher} />
+        <Route exact path={`${REPO_REGEX}/:view(browser)/:branch/:path*`} component={RepositoryNavigation} />
         {/* TODO: Add editor component */}
-        <Route exact path='/repos/:owner/:repo/:view(editor)/:branch/:path+' component={Sandbox} />
+        <Route exact path={`${REPO_REGEX}/:view(editor)/:branch/:path+`} component={Sandbox} />
       </div>
     </Router>
   </Provider>

--- a/src/components/BranchNavigation.js
+++ b/src/components/BranchNavigation.js
@@ -23,9 +23,7 @@ class BranchNavigation extends React.Component {
    * When component first initializes, execute following lifecycle actions
    */
   async componentDidMount() {
-    const { owner, repo } = this.props.match.params;
-
-    const branches = await getBranches(owner, repo);
+    const branches = await getBranches(this.props.match.params.repo);
     this.setState({
       isLoaded: true,
       branches
@@ -37,11 +35,8 @@ class BranchNavigation extends React.Component {
    * @param {Object} prevProps Updated query string
    */
   async componentDidUpdate(prevProps) {
-    const { owner: prevOwner, repo: prevRepo } = prevProps.match.params;
-    const { owner, repo } = this.props.match.params;
-
-    if (prevOwner !== owner || prevRepo !== repo) {
-      const branches = await getBranches(owner, repo);
+    if (prevProps.match.params.repo !== this.props.match.params.repo) {
+      const branches = await getBranches(this.props.match.params.repo);
       this.setState({
         isLoaded: true,
         branches
@@ -65,11 +60,7 @@ class BranchNavigation extends React.Component {
 
       branches.forEach((item) => {
         const key = `list-group-item-${item.name}`;
-
-        const { owner, repo } = this.props.match.params;
-
-        const linkToContent = `/repos/${owner}/${repo}/browser/${item.name}`;
-
+        const linkToContent = `/repos/${this.props.match.params.repo}/browser/${item.name}`;
         listGroupItems.push(<Divider key={`navigation-divider-${item.name}`}/>);
         listGroupItems.push(<NavigationListItem to={linkToContent} key={key} itemName={item.name} action />);
       });

--- a/src/components/MarkdownMusicSourceFetcher.js
+++ b/src/components/MarkdownMusicSourceFetcher.js
@@ -25,9 +25,9 @@ class MarkdownMusicSourceFetcher extends React.Component {
   }
 
   async componentDidMount() {
-    const { owner, repo, path } = this.props.match.params;
+    const { repo, path } = this.props.match.params;
 
-    const json = await getContents(owner, repo, path);
+    const json = await getContents(repo, path);
     this.setState({
       isLoaded: true,
       markdown: atob(json.content)

--- a/src/components/MusicMarkdownNavbar.js
+++ b/src/components/MusicMarkdownNavbar.js
@@ -11,8 +11,7 @@ import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import withStyles from '@material-ui/core/styles/withStyles';
 
-import { getRepositories, addRepository } from '../lib/github';
-import { REPOS_LOCAL_STORAGE_KEY } from '../lib/constants';
+import { getRepositories } from '../lib/github';
 import MusicToolbar from './MusicToolbar';
 
 const styles = (theme) => ({
@@ -45,11 +44,6 @@ class MusicMarkdownNavbar extends React.Component {
   render() {
     const { classes } = this.props;
     const { open } = this.state;
-
-    if (!localStorage.getItem(REPOS_LOCAL_STORAGE_KEY)) {
-      // TODO: sanitize this input when storing
-      addRepository('music-markdown', 'almost-in-time', '/', 'master');
-    }
 
     return (
       <>
@@ -115,14 +109,13 @@ class RepositoriesNavDropdown extends React.Component {
       const { reactRouterHoverInherit } = this.props.classes;
 
       repoList.forEach((repo) => {
-        const repoId = `${repo.owner}/${repo.repo}/${repo.branch}${repo.path}`;
         repoDropdownItems.push(
           <MenuItem component={NavLink}
-            to={`/repos/${repo.owner}/${repo.repo}/browser/${repo.branch}${repo.path}`}
-            key={`dropdown-item-${repoId}`}
+            to={`/repos/${repo}`}
+            key={`dropdown-item-${repo}`}
             onClick={this.handleClose}
             className={reactRouterHoverInherit}>
-            {repoId}
+            {repo}
           </MenuItem>);
       });
     }
@@ -139,6 +132,14 @@ class RepositoriesNavDropdown extends React.Component {
 
         <Menu id='dropdown-menu' anchorEl={this.anchorEl} open={open} onClose={this.handleClose}>
           {repoDropdownItems}
+          <Divider />
+          <MenuItem component={NavLink}
+            to='/repos'
+            key='edit-repos'
+            onClick={this.handleClose}
+            className={this.props.classes.reactRouterHoverInherit}>
+            Edit Repositories
+          </MenuItem>
         </Menu>
       </>
     );

--- a/src/components/RepositoryEditor.js
+++ b/src/components/RepositoryEditor.js
@@ -1,13 +1,13 @@
 import React from 'react';
-import {
-  List,
-  ListItem,
-  ListItemAvatar,
-  ListItemText,
-  ListItemSecondaryAction,
-  Avatar,
-  IconButton } from '@material-ui/core';
-import { Book, Delete } from '@material-ui/icons';
+import Avatar from '@material-ui/core/Avatar';
+import Book from '@material-ui/icons/Book';
+import Delete from '@material-ui/icons/Delete';
+import IconButton from '@material-ui/core/IconButton';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemAvatar from '@material-ui/core/ListItemAvatar';
+import ListItemText from '@material-ui/core/ListItemText';
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
 import AddRepository from './AddRepository';
 import { getRepositories, deleteRepository, addRepository } from '../lib/github';
 

--- a/src/components/RepositoryEditor.js
+++ b/src/components/RepositoryEditor.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import {
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  ListItemSecondaryAction,
+  Avatar,
+  IconButton } from '@material-ui/core';
+import { Book, Delete } from '@material-ui/icons';
+import AddRepository from './AddRepository';
+import { getRepositories, deleteRepository, addRepository } from '../lib/github';
+
+
+class ListRepositories extends React.Component {
+  state = {
+    repos: [],
+  }
+
+  handleAddRepository = async (repo) => {
+    await addRepository(repo);
+    this.loadRepositories();
+  }
+
+  handleDeleteRepository = (repo) => {
+    deleteRepository(repo);
+    this.loadRepositories();
+  }
+
+  loadRepositories = () => {
+    this.setState({
+      repos: getRepositories()
+    });
+  }
+
+  componentDidMount = () => {
+    this.loadRepositories();
+  }
+
+  render = () => (
+    <>
+      <List>
+        {this.state.repos.map((repo) => (
+          <ListItem button key={`repo-item-${repo}`}>
+            <ListItemAvatar>
+              <Avatar>
+                <Book />
+              </Avatar>
+            </ListItemAvatar>
+            <ListItemText primary={repo} />
+            <ListItemSecondaryAction>
+              <IconButton aria-label="Delete" onClick={() => this.handleDeleteRepository(repo)}>
+                <Delete />
+              </IconButton>
+            </ListItemSecondaryAction>
+          </ListItem>
+        ))}
+      </List>
+      <AddRepository handleAddRepository={this.handleAddRepository} />
+    </>
+  );
+}
+
+const RepositoryEditor = () => (
+  <ListRepositories />
+);
+
+export default RepositoryEditor;

--- a/src/components/RepositoryNavigation.js
+++ b/src/components/RepositoryNavigation.js
@@ -20,9 +20,9 @@ class RepositoryNavigation extends React.Component {
   }
 
   async componentDidMount() {
-    const { owner, repo, path, branch } = this.props.match.params;
+    const { repo, path, branch } = this.props.match.params;
 
-    const contents = await getContents(owner, repo, path, branch);
+    const contents = await getContents(repo, path, branch);
     this.setState({
       isLoaded: true,
       contents
@@ -34,11 +34,11 @@ class RepositoryNavigation extends React.Component {
    * @param {Object} prevProps Props before update
    */
   async componentDidUpdate(prevProps) {
-    const { owner: prevOwner, repo: prevRepo, path: prevPath, branch: prevBranch } = prevProps.match.params;
-    const { owner, repo, path, branch } = this.props.match.params;
+    const { repo: prevRepo, path: prevPath, branch: prevBranch } = prevProps.match.params;
+    const { repo, path, branch } = this.props.match.params;
 
-    if (prevOwner !== owner || prevRepo !== repo || prevPath !== path || prevBranch !== branch) {
-      const contents = await getContents(owner, repo, path, branch);
+    if (prevRepo !== repo || prevPath !== path || prevBranch !== branch) {
+      const contents = await getContents(repo, path, branch);
       this.setState({
         isLoaded: true,
         contents
@@ -61,7 +61,7 @@ class RepositoryNavigation extends React.Component {
     contents.forEach((item) => {
       const key = `list-group-item-${item.name}`;
 
-      const { owner, repo, branch } = this.props.match.params;
+      const { repo, branch } = this.props.match.params;
 
       let viewType = 'error';
       let itemJsx = <div>File type {item.type} not supported</div>;
@@ -74,7 +74,7 @@ class RepositoryNavigation extends React.Component {
         itemJsx = item.name;
       }
 
-      const linkToContent = `/repos/${owner}/${repo}/${viewType}/${branch}/${item.path}`;
+      const linkToContent = `/repos/${repo}/${viewType}/${branch}/${item.path}`;
 
       listGroupItems.push(<Divider key={`navigation-divider-${item.name}`}/>);
       listGroupItems.push(<NavigationListItem to={linkToContent} key={key} action itemName={itemJsx} />);

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -3,17 +3,16 @@ import { REPOS_LOCAL_STORAGE_KEY, GITHUB_TOKEN_LOCAL_STORAGE_KEY, GITHUB_API_URL
 /**
  * Returns a Promise of the contents of a file or directory in a GitHub repository.
  * See https://developer.github.com/v3/repos/contents/#get-contents
- * @param {string} owner Account owner of the repo
- * @param {string} repo Repo name
+ * @param {string} repo The owner and repo in the form :owner/:repo
  * @param {string} path The directory or file to retrieve
  * @param {string} branch The branch to retrive contents from
  * @return {Object} JSON dictionary of repository contents
  */
-export async function getContents(owner, repo, path, branch) {
+export async function getContents(repo, path, branch) {
   if (path === undefined || path.length === 0) {
     path = '';
   }
-  const apiUrl = getApiUrl(`/repos/${owner}/${repo}/contents/${path}`, branch);
+  const apiUrl = getApiUrl(`/repos/${repo}/contents/${path}`, branch);
   const response = await fetch(apiUrl);
   return response.json();
 }
@@ -31,31 +30,52 @@ export function getRepositories() {
   }
 }
 
-/**
- * Returns a promise of a list of branches for the given repository.
- * @param {string} owner Account owner of the repo
- * @param {string} repo Repo name
- */
-export async function getBranches(owner, repo) {
-  const apiUrl = getApiUrl(`/repos/${owner}/${repo}/branches`);
+async function verifyRepoExists(repo) {
+  const apiUrl = getApiUrl(`/repos/${repo}`);
   const response = await fetch(apiUrl);
+  debugger;
+  if (response.status === 404) {
+    throw new Error(`"${repo}" not found on GitHub.`);
+  }
+}
 
-  return response.json();
+function verifyRepoUnregistered(repo) {
+  for (const r of getRepositories()) {
+    if (r === repo) {
+      throw new Error(`"${repo}" is already registered.`);
+    }
+  }
 }
 
 /**
  * Adds a desired GitHub repo to localStorage.
- * @param {string} owner Repo owner
- * @param {string} repo Repo name
- * @param {string} path Subdirectory
- * @param {string} branch Branch name
+ * @param {string} repo The owner and repo in the form :owner/:repo
  */
-export function addRepository(owner, repo, path, branch) {
-  const repoMap = { owner, repo, path, branch };
-  const storedRepos = getRepositories();
-  const repoList = storedRepos.length > 0 ? storedRepos : [];
-  repoList.push(repoMap);
-  localStorage.setItem(REPOS_LOCAL_STORAGE_KEY, JSON.stringify(repoList));
+export async function addRepository(repo) {
+  verifyRepoUnregistered(repo);
+  await verifyRepoExists(repo);
+  const repos = getRepositories();
+  repos.push(repo);
+  localStorage.setItem(REPOS_LOCAL_STORAGE_KEY, JSON.stringify(repos));
+}
+
+/**
+ * Returns a promise of a list of branches for the given repository.
+ * @param {string} repo The owner and repo in the form :owner/:repo
+ */
+export async function getBranches(repo) {
+  const apiUrl = getApiUrl(`/repos/${repo}/branches`);
+  const response = await fetch(apiUrl);
+  return response.json();
+}
+
+/**
+ * Removes a GitHub repo from localStorage.
+ * @param {string} repo The owner and repo in the form :owner/:repo
+ */
+export function deleteRepository(repo) {
+  const repos = getRepositories().filter((r) => r !== repo);
+  localStorage.setItem(REPOS_LOCAL_STORAGE_KEY, JSON.stringify(repos));
 }
 
 /**

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -33,7 +33,6 @@ export function getRepositories() {
 async function verifyRepoExists(repo) {
   const apiUrl = getApiUrl(`/repos/${repo}`);
   const response = await fetch(apiUrl);
-  debugger;
   if (response.status === 404) {
     throw new Error(`"${repo}" not found on GitHub.`);
   }

--- a/src/lib/github.spec.js
+++ b/src/lib/github.spec.js
@@ -1,20 +1,38 @@
 import { GITHUB_TOKEN_LOCAL_STORAGE_KEY } from './constants';
-import { getRepositories, addRepository, getApiUrl } from './github';
+import { getRepositories, deleteRepository, addRepository, getApiUrl } from './github';
 
 describe('GitHub API', () => {
   afterEach(() => {
+    fetch.resetMocks();
     localStorage.clear();
   });
 
-  test('getRepositories contains new repo when repo is added to localStorage', () => {
-    addRepository('music-markdown', 'almost-in-time', '/');
+  test('getRepositories contains new repo when repo is added with addRepository', async () => {
+    fetch.mockResponse(JSON.stringify({}));
+    await addRepository('music-markdown/almost-in-time');
     const actualRepos = getRepositories();
-    const expectedRepo = {
-      'owner': 'music-markdown',
-      'repo': 'almost-in-time',
-      'path': '/'
-    };
+    const expectedRepo = 'music-markdown/almost-in-time';
     expect(actualRepos).toContainEqual(expectedRepo);
+  });
+
+  test('addRepository throws error when repo does not exist', () => {
+    fetch.mockResponse(JSON.stringify({}), { status: 404 });
+    expect(addRepository('some-repo/that-doesnt-exist')).rejects.toThrow();
+  });
+
+  test('addRepository throws error when repo is already registered', async () => {
+    fetch.mockResponse(JSON.stringify({}));
+    await addRepository('valid-owner/valid-repo');
+    expect(addRepository('valid-owner/valid-repo')).rejects.toThrow();
+  });
+
+  test('deleteRepository removes the correct', async () => {
+    fetch.mockResponse(JSON.stringify({}));
+    await addRepository('valid-owner/valid-repo-1');
+    await addRepository('valid-owner/valid-repo-2');
+    deleteRepository('valid-owner/valid-repo-1');
+    const actualRepos = getRepositories();
+    expect(actualRepos).toEqual(['valid-owner/valid-repo-2']);
   });
 
   test('getApiUrl returns API url with access token when localStorage contains github token', () => {
@@ -22,4 +40,7 @@ describe('GitHub API', () => {
     const actualUrl = getApiUrl('/some/path');
     expect(actualUrl.searchParams.get('access_token')).toEqual('music-markdown-github-token');
   });
+
+  // TODO: Write tests for getBranches
+  // TODO: Write tests for getContents
 });

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,2 @@
+// mocks for fetch
+global.fetch = require('jest-fetch-mock');


### PR DESCRIPTION
This change provides a mechanism to configure repositories in Music Markdown.

We also overhauled how we store GitHub repos in localStorage. Repos are now treated as a string of the form `repo-owner/repo-name` instead of as an object. This should make Jesse happy as he wanted this in the first place.

To support this, I updated the routing rules to treat `repo-owner/repo-name` as a single token, which required going through all the code and replacing references of (owner, repo) pairs with just a single reference.

I also added tests for the github requests. This involved introducing a mock for the global fetch.

![repository-editor](https://user-images.githubusercontent.com/361429/54896434-6db77c80-4e81-11e9-87fc-c8f71568afa6.gif)

I should mention – the gif might mislead you to think that it's showing autocompletions. The values in the list were values I had typed in previous testing sessions.