### PR TITLE
Give the Add File dialog box a face lift.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1449,7 +1449,7 @@
       "resolved": "https://registry.npmjs.org/abcjs/-/abcjs-5.6.7.tgz",
       "integrity": "sha512-P0kDNhmB/gmvQuoR7pUH2bcCi4Bj94J9wnkmvuOl8NJQOUmGmMsgdiODESREDmQ26axIELYtfUnjumC7Eu20tQ==",
       "requires": {
-        "midi": "git+https://github.com/paulrosen/MIDI.js.git#e593ffef81a0350f99448e3ab8111957145ff6b2"
+        "midi": "git+https://github.com/paulrosen/MIDI.js.git#abcjs"
       }
     },
     "accepts": {
@@ -3305,7 +3305,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3323,11 +3324,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3340,15 +3343,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3451,7 +3457,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3461,6 +3468,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3473,17 +3481,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3500,6 +3511,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3572,7 +3584,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3582,6 +3595,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3657,7 +3671,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3687,6 +3702,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3704,6 +3720,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3742,11 +3759,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -7204,7 +7223,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7228,6 +7248,7 @@
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7240,7 +7261,8 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -7249,7 +7271,8 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7352,7 +7375,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7362,6 +7386,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7374,17 +7399,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -7401,6 +7429,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7473,7 +7502,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7483,6 +7513,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7558,7 +7589,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7588,6 +7620,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7605,6 +7638,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7643,11 +7677,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -10958,6 +10994,11 @@
         "uc.micro": "^1.0.5"
       }
     },
+    "markdown-it-fence": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/markdown-it-fence/-/markdown-it-fence-0.1.3.tgz",
+      "integrity": "sha512-mdZbkwJUyZXhyDX4QzD+WnIhxWBq9oIIJU22E6jCT7MHgIp79oEOJfwXIl/HqmfIxnXEdC47sBGn4h6chM4DKw=="
+    },
     "markdown-it-meta": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it-meta/-/markdown-it-meta-0.0.1.tgz",
@@ -10967,11 +11008,13 @@
       }
     },
     "markdown-it-music": {
-      "version": "github:music-markdown/markdown-it-music#253a6c3175d923eaf85f6e4bdd38e9bb3639c3ec",
-      "from": "github:music-markdown/markdown-it-music",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-it-music/-/markdown-it-music-0.0.4.tgz",
+      "integrity": "sha512-RZPtSbnd+PuQFheCB6hXP3q5Er6alpiT2vlmN2im4MxZOT/clumrx/6o6WGHW/ZfYPS5M7a0I8jkuEFurtyqhA==",
       "requires": {
         "abcjs": "^5.6.4",
         "fast-memoize": "^2.5.1",
+        "markdown-it-fence": "^0.1.3",
         "markdown-it-meta": "0.0.1",
         "randomcolor": "^0.5.4",
         "svg.js": "^2.7.1"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "history": "^4.9.0",
     "jquery": "^3.3.1",
     "markdown-it": "^8.4.2",
-    "markdown-it-music": "github:music-markdown/markdown-it-music",
+    "markdown-it-music": "^0.0.4",
     "node-sass": "^4.11.0",
     "normalize-url": "^4.2.0",
     "npm": "^6.9.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "history": "^4.9.0",
     "jquery": "^3.3.1",
     "markdown-it": "^8.4.2",
-    "markdown-it-music": "^0.0.4",
+    "markdown-it-music": "~0.0.4",
     "node-sass": "^4.11.0",
     "normalize-url": "^4.2.0",
     "npm": "^6.9.0",

--- a/src/components/AddNewFile.js
+++ b/src/components/AddNewFile.js
@@ -1,16 +1,27 @@
 import Add from '@material-ui/icons/Add';
 import Button from '@material-ui/core/Button';
+import Card from '@material-ui/core/Card';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import ErrorSnackbar from './ErrorSnackbar';
 import Fab from '@material-ui/core/Fab';
 import Grid from '@material-ui/core/Grid';
+import InputAdornment from '@material-ui/core/InputAdornment';
 import React from 'react';
 import { Redirect } from 'react-router-dom';
 import TextField from '@material-ui/core/TextField';
+import Typography from '@material-ui/core/Typography';
 import { putContents } from '../lib/github';
+import withStyles from '@material-ui/core/styles/withStyles';
+
+const styles = () => ({
+  previewCard: {
+    padding: 12,
+  },
+});
 
 class AddNewFile extends React.Component {
   state = {
@@ -41,10 +52,7 @@ class AddNewFile extends React.Component {
     const { newFileName } = this.state;
 
     const pathName = path ? `${path}/${newFileName}.md` : `${newFileName}.md`;
-    const content = btoa(`---
----
-
-# ${newFileName}`);
+    const content = btoa(this.getTemplateContents());
 
     const response = await putContents(repo, pathName, content, undefined, branch);
 
@@ -70,15 +78,18 @@ class AddNewFile extends React.Component {
     this.setState({ error: false });
   }
 
+  isValidFileName = () => (!!this.state.newFileName.match(/^[^<>:"\/\\|?*]+$/))
+
+  getTemplateContents = () => (`---\n---\n\n# ${this.state.newFileName}`);
+
   render() {
     const { newFileOpen, toEditor, newFileName } = this.state;
+    const { classes, location } = this.props;
+    const parts = location.pathname.split('/');
 
     if (toEditor) {
-      const { location } = this.props;
-      const parts = location.pathname.split('/');
       parts[4] = 'editor';
-
-      return <Redirect to={`${parts.join('/')}${newFileName}.md/`} />;
+      return <Redirect to={`${parts.join('/')}${newFileName}.md`} />;
     }
 
     return (
@@ -87,22 +98,39 @@ class AddNewFile extends React.Component {
           <Fab aria-label='Add' onClick={this.handleAddNewFileOpen}>
             <Add />
           </Fab>
-          <Dialog open={newFileOpen} aria-labelledby='add-new-file-dialog'>
-            <DialogTitle id='add-new-file-dialog-title'>New File</DialogTitle>
+          <Dialog open={newFileOpen} aria-labelledby='add-new-file-dialog' fullWidth={true}>
+            <DialogTitle id='add-new-file-dialog-title'>Create New Music Markdown File</DialogTitle>
             <DialogContent>
+              <DialogContentText>
+                <Card className={classes.previewCard}>
+                  <Typography variant="caption" color="textSecondary" gutterBottom>
+                    Preview
+                  </Typography>
+                  <Typography variant="body1" color="textPrimary">
+                    <pre>{this.getTemplateContents()}</pre>
+                  </Typography>
+                </Card>
+              </DialogContentText>
               <TextField
                 autoFocus
                 margin='dense'
                 id='owner'
-                label='File Name'
+                label='Music Markdown File Name'
                 value={this.state.newFileName}
                 onChange={(e) => this.handleUpdateFileName(e)}
                 fullWidth
+                error={!this.isValidFileName()}
+                helperText={!this.isValidFileName()
+                  ? 'Invalid file name'
+                  : <div>{parts[2]}/{parts[3]}/{parts[5]}/{parts.slice(6).join('/')}{newFileName}.md</div>}
+                InputProps={{
+                  endAdornment: <InputAdornment position="end">.md</InputAdornment>
+                }}
               />
             </DialogContent>
             <DialogActions>
-              <Button onClick={this.handleAddNewFileClose}>Cancel</Button>
-              <Button onClick={this.handleAddNewFile}>Create</Button>
+              <Button onClick={this.handleAddNewFileClose} color="secondary">Cancel</Button>
+              <Button onClick={this.handleAddNewFile} color="primary" disabled={!this.isValidFileName()}>Create</Button>
             </DialogActions>
           </Dialog>
         </Grid>
@@ -115,4 +143,4 @@ class AddNewFile extends React.Component {
   }
 }
 
-export default AddNewFile;
+export default withStyles(styles, { withTheme: true })(AddNewFile);

--- a/src/components/AddNewFile.js
+++ b/src/components/AddNewFile.js
@@ -78,7 +78,7 @@ class AddNewFile extends React.Component {
     this.setState({ error: false });
   }
 
-  isValidFileName = () => (!!this.state.newFileName.match(/^[^<>:"\/\\|?*]+$/))
+  isValidFileName = () => (!!this.state.newFileName.match(/^[^<>:"/\\|?*]+$/))
 
   getTemplateContents = () => (`---\n---\n\n# ${this.state.newFileName}`);
 

--- a/src/components/AddNewFile.js
+++ b/src/components/AddNewFile.js
@@ -48,13 +48,11 @@ class AddNewFile extends React.Component {
   }
 
   handleAddNewFile = async () => {
-    const { repo, branch, path } = this.props.match.params;
-    const { newFileName } = this.state;
-
-    const pathName = path ? `${path}/${newFileName}.md` : `${newFileName}.md`;
+    const { repo, branch } = this.props.match.params;
+    const path = this.getNewFilePath();
     const content = btoa(this.getTemplateContents());
 
-    const response = await putContents(repo, pathName, content, undefined, branch);
+    const response = await putContents(repo, path, content, undefined, branch);
 
     if (response.status !== 201) {
       this.handleShowError(`${response.status}: ${response.statusText}`);
@@ -79,15 +77,20 @@ class AddNewFile extends React.Component {
   }
 
   isValidFileName = () => (!!this.state.newFileName.match(/^[^<>:"/\\|?*]+$/))
-
-  getTemplateContents = () => (`---\n---\n\n# ${this.state.newFileName}`);
+  getTemplateContents = () => (`---\n---\n\n# ${this.state.newFileName}`)
+  getNewFilePath = () => {
+    const file = this.state.newFileName;
+    const path = this.props.match.params.path;
+    return path ? `${path}/${file}.md` : `${file}`;
+  }
 
   render() {
-    const { newFileOpen, toEditor, newFileName } = this.state;
     const { classes, location } = this.props;
-    const parts = location.pathname.split('/');
+    const { newFileOpen, toEditor, newFileName } = this.state;
+    const { repo, branch } = this.props.match.params;
 
     if (toEditor) {
+      const parts = location.pathname.split('/');
       parts[4] = 'editor';
       return <Redirect to={`${parts.join('/')}${newFileName}.md`} />;
     }
@@ -122,7 +125,7 @@ class AddNewFile extends React.Component {
                 error={!this.isValidFileName()}
                 helperText={!this.isValidFileName()
                   ? 'Invalid file name'
-                  : <div>{parts[2]}/{parts[3]}/{parts[5]}/{parts.slice(6).join('/')}{newFileName}.md</div>}
+                  : <div>{repo}/{branch}/{this.getNewFilePath()}</div>}
                 InputProps={{
                   endAdornment: <InputAdornment position="end">.md</InputAdornment>
                 }}

--- a/src/components/BranchNavigation.js
+++ b/src/components/BranchNavigation.js
@@ -58,7 +58,7 @@ class BranchNavigation extends React.Component {
 
   render() {
     const { isLoaded, branches } = this.state;
-    const { classes } = this.props;
+    const { classes, location, match } = this.props;
 
     if (!isLoaded) {
       return (
@@ -68,14 +68,14 @@ class BranchNavigation extends React.Component {
 
     return (
       <>
-        <DirectoryBreadcrumbs pathname={this.props.location.pathname} />
+        <DirectoryBreadcrumbs pathname={location.pathname} />
         <div className={classes.root}>
           <List>
             {
               branches.map((item) => (
                 <ListItem button component={Link}
                   key={`list-group-item-${item.name}`}
-                  to={`/repos/${this.props.match.params.repo}/browser/${item.name}/`}>
+                  to={`/repos/${match.params.repo}/browser/${item.name}/`}>
                   <ListItemAvatar>
                     <Avatar>
                       <CallSplit />

--- a/src/components/RepositoryNavigation.js
+++ b/src/components/RepositoryNavigation.js
@@ -97,13 +97,17 @@ class RepositoryNavigation extends React.Component {
               contents.map((item) => (
                 <ListItem button component={Link}
                   key={`list-group-item-${item.name}`}
-                  to={`/repos/${repo}/${item.type === 'dir' ? 'browser' : 'viewer'}/${branch}/${item.path}/`}>
+                  to={item === 'dir'
+                    ? `/repos/${repo}/browser/${branch}/${item.path}/`
+                    : `/repos/${repo}/viewer/${branch}/${item.path}`}>
                   <ListItemAvatar>
                     <Avatar>
                       {item.type === 'dir' ? <FolderIcon /> : <DescriptionIcon /> }
                     </Avatar>
                   </ListItemAvatar>
-                  <ListItemText primary={item.type === 'dir' ? <i>{item.name}</i> : item.name}></ListItemText>
+                  {item.type === 'dir'
+                    ? <ListItemText secondary={item.name}></ListItemText>
+                    : <ListItemText primary={item.name}></ListItemText>}
                 </ListItem>
               ))
             }

--- a/src/components/RepositoryNavigation.js
+++ b/src/components/RepositoryNavigation.js
@@ -97,7 +97,7 @@ class RepositoryNavigation extends React.Component {
               contents.map((item) => (
                 <ListItem button component={Link}
                   key={`list-group-item-${item.name}`}
-                  to={item === 'dir'
+                  to={item.type === 'dir'
                     ? `/repos/${repo}/browser/${branch}/${item.path}/`
                     : `/repos/${repo}/viewer/${branch}/${item.path}`}>
                   <ListItemAvatar>

--- a/src/components/RouterBreadcrumbs.js
+++ b/src/components/RouterBreadcrumbs.js
@@ -63,6 +63,7 @@ const DirectoryBreadcrumbs = ({ pathname, classes }) => {
   const keyBase = 'breadcrumb-item-';
 
   const subDirectoriesArr = pathname.split('/').filter((value) => !!value);
+  subDirectoriesArr[3] = 'browser';
 
   const breadcrumbItems = buildBreadcrumb(subDirectoriesArr, classes);
 


### PR DESCRIPTION
This PR primarily introduces a face lift to the Add File dialog box:

![add-file-face-lift](https://user-images.githubusercontent.com/361429/55764117-1091fe00-5a1f-11e9-8dd9-8ac600b74d75.gif)

Demonstrated in the GIF:

- File name validation
- Mini preview window to show what will be published
- Full path to the filename is indicated as hint text

Also a few minor fixes including:

- Switch markdown-it-music to our npm version
- Don't put trailing slashes on file name URLs
- Fix breadcrumbs to set /browser/ so that using the breadcrumbs in the editor works correctly