### PR TITLE
NPM package for markdown-it-music

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3323,11 +3323,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3340,15 +3342,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3451,7 +3456,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3461,6 +3467,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3473,17 +3480,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3500,6 +3510,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3572,7 +3583,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3582,6 +3594,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3687,6 +3700,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -10958,6 +10972,11 @@
         "uc.micro": "^1.0.5"
       }
     },
+    "markdown-it-fence": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/markdown-it-fence/-/markdown-it-fence-0.1.3.tgz",
+      "integrity": "sha512-mdZbkwJUyZXhyDX4QzD+WnIhxWBq9oIIJU22E6jCT7MHgIp79oEOJfwXIl/HqmfIxnXEdC47sBGn4h6chM4DKw=="
+    },
     "markdown-it-meta": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it-meta/-/markdown-it-meta-0.0.1.tgz",
@@ -10967,11 +10986,13 @@
       }
     },
     "markdown-it-music": {
-      "version": "github:music-markdown/markdown-it-music#253a6c3175d923eaf85f6e4bdd38e9bb3639c3ec",
-      "from": "github:music-markdown/markdown-it-music",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-it-music/-/markdown-it-music-0.0.4.tgz",
+      "integrity": "sha512-RZPtSbnd+PuQFheCB6hXP3q5Er6alpiT2vlmN2im4MxZOT/clumrx/6o6WGHW/ZfYPS5M7a0I8jkuEFurtyqhA==",
       "requires": {
         "abcjs": "^5.6.4",
         "fast-memoize": "^2.5.1",
+        "markdown-it-fence": "^0.1.3",
         "markdown-it-meta": "0.0.1",
         "randomcolor": "^0.5.4",
         "svg.js": "^2.7.1"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "history": "^4.9.0",
     "jquery": "^3.3.1",
     "markdown-it": "^8.4.2",
-    "markdown-it-music": "github:music-markdown/markdown-it-music",
+    "markdown-it-music": "~0.0.4",
     "node-sass": "^4.11.0",
     "normalize-url": "^4.2.0",
     "npm": "^6.9.0",


### PR DESCRIPTION
Let's try this again, without the merge conflicts...

Use [markdown-it-music's npm package](https://www.npmjs.com/package/markdown-it-music) in `music-markdown` project.