### PR TITLE
make the preview pane monospace again

### DIFF
--- a/src/components/AddNewFile.js
+++ b/src/components/AddNewFile.js
@@ -18,11 +18,9 @@ import { putContents } from '../lib/github';
 import withStyles from '@material-ui/core/styles/withStyles';
 
 const styles = () => ({
-  previewCard: {
-    padding: 12,
-  },
   whitespacePre: {
-    whiteSpace: 'pre-line'
+    whiteSpace: 'pre-line',
+    fontFamily: 'monospace',
   }
 });
 


### PR DESCRIPTION
The preview pane lost its monospace-y-ness. Added the appropriate class to get it back.