### PR TITLE
Small Screen Music Toolbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1449,7 +1449,7 @@
       "resolved": "https://registry.npmjs.org/abcjs/-/abcjs-5.6.7.tgz",
       "integrity": "sha512-P0kDNhmB/gmvQuoR7pUH2bcCi4Bj94J9wnkmvuOl8NJQOUmGmMsgdiODESREDmQ26axIELYtfUnjumC7Eu20tQ==",
       "requires": {
-        "midi": "git+https://github.com/paulrosen/MIDI.js.git#abcjs"
+        "midi": "git+https://github.com/paulrosen/MIDI.js.git#e593ffef81a0350f99448e3ab8111957145ff6b2"
       }
     },
     "accepts": {
@@ -2974,6 +2974,12 @@
         "node-int64": "^0.4.0"
       }
     },
+    "btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "dev": true
+    },
     "buffer": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
@@ -3305,8 +3311,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3324,13 +3329,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3343,18 +3346,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3457,8 +3457,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3468,7 +3467,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3481,20 +3479,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3511,7 +3506,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3584,8 +3578,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3595,7 +3588,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3671,8 +3663,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3702,7 +3693,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3720,7 +3710,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3759,13 +3748,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -5336,6 +5323,12 @@
         "buffer-indexof": "^1.0.0"
       }
     },
+    "docopt": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/docopt/-/docopt-0.6.2.tgz",
+      "integrity": "sha1-so6eIiDaXsSffqW7JKR3h0Be6xE=",
+      "dev": true
+    },
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -5451,6 +5444,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "ejs": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
+      "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
+      "dev": true
     },
     "electron-to-chromium": {
       "version": "1.3.119",
@@ -7207,9 +7206,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+      "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
       "optional": true,
       "requires": {
         "nan": "^2.9.2",
@@ -7223,8 +7222,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7232,7 +7230,7 @@
           "optional": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7242,37 +7240,32 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7288,7 +7281,7 @@
           }
         },
         "deep-extend": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true,
           "optional": true
         },
@@ -7331,7 +7324,7 @@
           }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7349,11 +7342,11 @@
           "optional": true
         },
         "iconv-lite": {
-          "version": "0.4.21",
+          "version": "0.4.24",
           "bundled": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
@@ -7375,8 +7368,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7386,7 +7378,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7399,27 +7390,24 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
-          "version": "2.2.4",
+          "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
           }
         },
         "minizlib": {
-          "version": "1.1.0",
+          "version": "1.2.1",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7429,7 +7417,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7440,7 +7427,7 @@
           "optional": true
         },
         "needle": {
-          "version": "2.2.0",
+          "version": "2.2.4",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7450,17 +7437,17 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.0",
+          "version": "0.10.3",
           "bundled": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
+            "needle": "^2.2.1",
             "nopt": "^4.0.1",
             "npm-packlist": "^1.1.6",
             "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
             "tar": "^4"
@@ -7476,12 +7463,12 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.3",
+          "version": "1.0.5",
           "bundled": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.1.10",
+          "version": "1.2.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7502,8 +7489,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7513,7 +7499,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7548,11 +7533,11 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.7",
+          "version": "1.2.8",
           "bundled": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
+            "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
@@ -7580,17 +7565,16 @@
           }
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "version": "5.1.2",
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7603,7 +7587,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.6.0",
           "bundled": true,
           "optional": true
         },
@@ -7620,7 +7604,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7638,7 +7621,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7649,16 +7631,16 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.1",
+          "version": "4.4.8",
           "bundled": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
+            "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
             "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.2"
           }
         },
@@ -7668,22 +7650,20 @@
           "optional": true
         },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
-          "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "version": "3.0.3",
+          "bundled": true
         }
       }
     },
@@ -10811,6 +10791,11 @@
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "lodash-es": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.11.tgz",
+      "integrity": "sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -19427,6 +19412,11 @@
         "performance-now": "^2.1.0"
       }
     },
+    "raf-schd": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.0.tgz",
+      "integrity": "sha512-m7zq0JkIrECzw9mO5Zcq6jN4KayE34yoIS9hJoiZNXyOAT06PPA8PrR+WtJIeFW09YjUfNkMMN9lrmAt6BURCA=="
+    },
     "railroad-diagrams": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
@@ -19811,6 +19801,18 @@
         "react-is": "^16.8.2"
       }
     },
+    "react-resize-detector": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-4.1.3.tgz",
+      "integrity": "sha512-tzVDVFxhUVdTjxyR1OqNggkbFAA7srawgwhcm4XQjyGq/R8M13MiceI+4C7xfzHqaKk0Oq7ErIXexGGSgQEKcQ==",
+      "requires": {
+        "lodash": "^4.17.11",
+        "lodash-es": "^4.17.11",
+        "prop-types": "^15.7.2",
+        "raf-schd": "^4.0.0",
+        "resize-observer-polyfill": "^1.5.1"
+      }
+    },
     "react-router": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
@@ -19930,6 +19932,468 @@
             "lodash": "^4.17.11",
             "source-map": "^0.5.0",
             "trim-right": "^1.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+          "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+          "optional": true,
+          "requires": {
+            "nan": "^2.9.2",
+            "node-pre-gyp": "^0.10.0"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "deep-extend": {
+              "version": "0.5.1",
+              "bundled": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.21",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": "^2.1.0"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "minipass": {
+              "version": "2.2.4",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.1.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.2.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "debug": "^2.1.2",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.10.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.0",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.1.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.3",
+              "bundled": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.1.10",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.7",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.5.1",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.0.5"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "bundled": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.5.0",
+              "bundled": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "chownr": "^1.0.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.2.4",
+                "minizlib": "^1.1.0",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.2"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true
+            }
           }
         },
         "source-map": {
@@ -20570,6 +21034,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.10.0",
@@ -21512,6 +21981,40 @@
         "amdefine": ">=0.0.4"
       }
     },
+    "source-map-explorer": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/source-map-explorer/-/source-map-explorer-1.8.0.tgz",
+      "integrity": "sha512-1Q0lNSw5J7pChKmjqniOCLbvLFi4KJfrtixk99CzvRcqFiGBJvRHMrw0PjLwKOvbuAo8rNOukJhEPA0Nj85xDw==",
+      "dev": true,
+      "requires": {
+        "btoa": "^1.2.1",
+        "convert-source-map": "^1.6.0",
+        "docopt": "^0.6.2",
+        "ejs": "^2.6.1",
+        "fs-extra": "^7.0.1",
+        "glob": "^7.1.3",
+        "opn": "^5.5.0",
+        "source-map": "^0.5.1",
+        "temp": "^0.9.0"
+      },
+      "dependencies": {
+        "opn": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
+          "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
+          "dev": true,
+          "requires": {
+            "is-wsl": "^1.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
     "source-map-resolve": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
@@ -22052,6 +22555,15 @@
         "block-stream": "*",
         "fstream": "^1.0.2",
         "inherits": "2"
+      }
+    },
+    "temp": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.0.tgz",
+      "integrity": "sha512-YfUhPQCJoNQE5N+FJQcdPz63O3x3sdT4Xju69Gj4iZe0lBKOtnAMi0SLj9xKhGkcGhsxThvTJ/usxtFPo438zQ==",
+      "dev": true,
+      "requires": {
+        "rimraf": "~2.6.2"
       }
     },
     "terser": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-container-dimensions": "^1.4.1",
     "react-dom": "^16.8.5",
     "react-redux": "^6.0.1",
+    "react-resize-detector": "^4.1.3",
     "react-router-dom": "^4.3.1",
     "react-scripts": "^2.1.8",
     "redux": "^4.0.1",
@@ -32,7 +33,8 @@
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "lint": "eslint .",
-    "fix-lint": "eslint . --fix"
+    "fix-lint": "eslint . --fix",
+    "analyze": "source-map-explorer build/static/js/*.js"
   },
   "browserslist": [
     ">0.2%",
@@ -47,6 +49,7 @@
     "eslint-config-google": "^0.12.0",
     "eslint-plugin-babel": "^5.3.0",
     "jest-fetch-mock": "^2.1.1",
-    "redux-devtools": "^3.5.0"
+    "redux-devtools": "^3.5.0",
+    "source-map-explorer": "^1.8.0"
   }
 }

--- a/src/components/MusicToolbar.js
+++ b/src/components/MusicToolbar.js
@@ -4,6 +4,7 @@ import Grid from '@material-ui/core/Grid';
 import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
 import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
 import React from 'react';
+import ReactResizeDetector from 'react-resize-detector';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import { YouTubeToggle } from './YouTube';
@@ -39,46 +40,6 @@ const styles = (theme) => ({
   }
 });
 
-function animate(prop, element, to) {
-  const ease = (time) => (1 + Math.sin(Math.PI * time - Math.PI / 2)) / 2;
-  const duration = 300;
-
-  let start = null;
-  const from = element[prop];
-  let cancelled = false;
-
-  const cancel = () => {
-    cancelled = true;
-  };
-
-  const step = (timestamp) => {
-    if (cancelled) {
-      return;
-    }
-
-    if (start === null) {
-      start = timestamp;
-    }
-    const time = Math.min(1, (timestamp - start) / duration);
-
-    element[prop] = ease(time) * (to - from) + from;
-
-    if (time >= 1) {
-      requestAnimationFrame(() => {});
-      return;
-    }
-
-    requestAnimationFrame(step);
-  };
-
-  if (from === to) {
-    return cancel;
-  }
-
-  requestAnimationFrame(step);
-  return cancel;
-}
-
 class MusicToolbar extends React.Component {
   constructor(props) {
     super(props);
@@ -91,6 +52,13 @@ class MusicToolbar extends React.Component {
   state = {
     canScrollLeft: false,
     canScrollRight: false
+  }
+
+  updateOnResize = () => {
+    this.setState({
+      canScrollLeft: this.toolbarRef.scrollLeft > 0,
+      canScrollRight: this.toolbarRef.scrollLeft + this.toolbarRef.clientWidth < this.toolbarRef.scrollWidth
+    });
   }
 
   handleTransposeClick = (event) => {
@@ -171,47 +139,49 @@ class MusicToolbar extends React.Component {
     const { canScrollLeft, canScrollRight } = this.state;
 
     return (
-      <Toolbar disableGutters={true}>
-        <Button
-          onClick={this.handleLeftScroll}
-          className={`${classes.scrollButton} ${!canScrollLeft ? classes.scrollHide : ''}`}>
-          <KeyboardArrowLeft />
-        </Button>
-        <Grid container direction='row' justify='center' alignItems='center' spacing={16}>
-          <div ref={this.handleToolbarRef} className={classes.flexWithWidth}>
-            <Grid item className={classes.option} >
-              <YouTubeToggle youTubeId={this.props.youTubeId} />
-            </Grid>
-            {[{ name: 'Transpose', clickCallback: this.handleTransposeClick, value: transposeAmount },
-              { name: 'Column Count', clickCallback: this.handleColumnClick, value: columnCount },
-              { name: 'Font Size', clickCallback: this.handleFontClick, value: fontSize }]
-              .map(({ name, clickCallback, value }) => (
-                <div key={name} className={classes.option}>
-                  <Grid item className={classes.words}>
-                    <Badge color='primary' badgeContent={value}>
-                      <Typography variant='body1' className={classes.padding}>{name}</Typography>
-                    </Badge>
-                  </Grid>
-                  <Grid item>
-                    <Button onClick={clickCallback}>
-                      <Typography variant='body2'>{this.decrease}</Typography>
-                    </Button>
-                  </Grid>
-                  <Grid item>
-                    <Button onClick={clickCallback}>
-                      <Typography variant='body2'>{this.increase}</Typography>
-                    </Button>
-                  </Grid>
-                </div>
-              ))}
-          </div>
-        </Grid>
-        <Button
-          onClick={this.handleRightScroll}
-          className={`${classes.scrollButton} ${!canScrollRight ? classes.scrollHide : ''}`}>
-          <KeyboardArrowRight />
-        </Button>
-      </Toolbar>
+      <ReactResizeDetector handleWidth refreshMode='debounce' refreshRate={200} onResize={this.updateOnResize}>
+        <Toolbar disableGutters={true}>
+          <Button
+            onClick={this.handleLeftScroll}
+            className={`${classes.scrollButton} ${!canScrollLeft ? classes.scrollHide : ''}`}>
+            <KeyboardArrowLeft />
+          </Button>
+          <Grid container direction='row' justify='center' alignItems='center' spacing={16}>
+            <div ref={this.handleToolbarRef} className={classes.flexWithWidth}>
+              <Grid item className={classes.option} >
+                <YouTubeToggle youTubeId={this.props.youTubeId} />
+              </Grid>
+              {[{ name: 'Transpose', clickCallback: this.handleTransposeClick, value: transposeAmount },
+                { name: 'Column Count', clickCallback: this.handleColumnClick, value: columnCount },
+                { name: 'Font Size', clickCallback: this.handleFontClick, value: fontSize }]
+                .map(({ name, clickCallback, value }) => (
+                  <div key={name} className={classes.option}>
+                    <Grid item className={classes.words}>
+                      <Badge color='primary' badgeContent={value}>
+                        <Typography variant='body1' className={classes.padding}>{name}</Typography>
+                      </Badge>
+                    </Grid>
+                    <Grid item>
+                      <Button onClick={clickCallback}>
+                        <Typography variant='body2'>{this.decrease}</Typography>
+                      </Button>
+                    </Grid>
+                    <Grid item>
+                      <Button onClick={clickCallback}>
+                        <Typography variant='body2'>{this.increase}</Typography>
+                      </Button>
+                    </Grid>
+                  </div>
+                ))}
+            </div>
+          </Grid>
+          <Button
+            onClick={this.handleRightScroll}
+            className={`${classes.scrollButton} ${!canScrollRight ? classes.scrollHide : ''}`}>
+            <KeyboardArrowRight />
+          </Button>
+        </Toolbar>
+      </ReactResizeDetector>
     );
   }
 }

--- a/src/components/MusicToolbar.js
+++ b/src/components/MusicToolbar.js
@@ -1,6 +1,8 @@
 import Badge from '@material-ui/core/Badge';
 import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
+import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
+import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
 import React from 'react';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
@@ -11,38 +13,106 @@ import { updateColumnCount } from '../redux/actions';
 import { updateFontSize } from '../redux/actions';
 import withStyles from '@material-ui/core/styles/withStyles';
 
-
 const styles = (theme) => ({
   padding: {
     padding: `0 ${theme.spacing.unit}px`,
+  },
+  words: {
+    lineHeight: 1.8,
+    whiteSpace: 'nowrap'
+  },
+  option: {
+    display: 'flex',
+    padding: 12
+  },
+  flexWithWidth: {
+    display: 'flex',
+    maxWidth: '65vw',
+    overflowX: 'hidden'
+  },
+  scrollButton: {
+    margin: 8
   }
 });
+
+function animate(prop, element, to) {
+  const ease = (time) => (1 + Math.sin(Math.PI * time - Math.PI / 2)) / 2;
+  const duration = 300;
+
+  let start = null;
+  const from = element[prop];
+  let cancelled = false;
+
+  const cancel = () => {
+    cancelled = true;
+  };
+
+  const step = (timestamp) => {
+    if (cancelled) {
+      return;
+    }
+
+    if (start === null) {
+      start = timestamp;
+    }
+    const time = Math.min(1, (timestamp - start) / duration);
+
+    element[prop] = ease(time) * (to - from) + from;
+
+    if (time >= 1) {
+      requestAnimationFrame(() => {});
+      return;
+    }
+
+    requestAnimationFrame(step);
+  };
+
+  if (from === to) {
+    return cancel;
+  }
+
+  requestAnimationFrame(step);
+  return cancel;
+}
 
 class MusicToolbar extends React.Component {
   constructor(props) {
     super(props);
 
-    this.handleTransposeClick = this.handleTransposeClick.bind(this);
-    this.handleColumnClick = this.handleColumnClick.bind(this);
-    this.handleFontClick = this.handleFontClick.bind(this);
-
     this.increase = '+1';
     this.decrease = '-1';
+    this.toolbarRef = undefined;
   }
 
-  handleTransposeClick(event) {
+  handleTransposeClick = (event) => {
     // TODO: Update history with new transposeAmount
     this.props.transpose(event.target.textContent === this.increase);
   }
 
-  handleColumnClick(event) {
+  handleColumnClick = (event) => {
     // TODO: Update history with new columnCount
     this.props.updateColumnCount(event.target.textContent === this.increase);
   }
 
-  handleFontClick(event) {
+  handleFontClick = (event) => {
     // TODO: Update history with new fontSize
     this.props.updateFontSize(event.target.textContent === this.increase);
+  }
+
+  handleLeftScroll = () => {
+    this.handleMoveScroll(-this.toolbarRef.clientWidth);
+  }
+
+  handleRightScroll = () => {
+    this.handleMoveScroll(this.toolbarRef.clientWidth);
+  }
+
+  handleMoveScroll = (delta) => {
+    animate('scrollLeft', this.toolbarRef, this.toolbarRef.scrollLeft + delta);
+  }
+
+  handleToolbarRef = (ref) => {
+    this.toolbarRef = ref;
   }
 
   render() {
@@ -50,33 +120,43 @@ class MusicToolbar extends React.Component {
 
     return (
       <Toolbar>
+        { this.toolbarRef && this.toolbarRef.scrollLeft > 0 ?
+          <Button onClick={this.handleLeftScroll} className={classes.scrollButton}>
+            <KeyboardArrowLeft />
+          </Button> :
+          undefined }
         <Grid container direction='row' justify='center' alignItems='center' spacing={16}>
-          {[{ name: 'Transpose', clickCallback: this.handleTransposeClick, value: transposeAmount },
-            { name: 'Column Count', clickCallback: this.handleColumnClick, value: columnCount },
-            { name: 'Font Size', clickCallback: this.handleFontClick, value: fontSize }]
-            .map(({ name, clickCallback, value }) => (
-              <React.Fragment key={name}>
-                <Grid item>
-                  <Badge color='primary' badgeContent={value}>
-                    <Typography variant='body1' className={classes.padding}>{name}</Typography>
-                  </Badge>
-                </Grid>
-                <Grid item>
-                  <Button onClick={clickCallback}>
-                    <Typography variant='body2'>{this.decrease}</Typography>
-                  </Button>
-                </Grid>
-                <Grid item>
-                  <Button onClick={clickCallback}>
-                    <Typography variant='body2'>{this.increase}</Typography>
-                  </Button>
-                </Grid>
-              </React.Fragment>
-            ))}
-          <Grid item>
-            <YouTubeToggle youTubeId={this.props.youTubeId} />
-          </Grid>
+          <div ref={this.handleToolbarRef} className={classes.flexWithWidth}>
+            <Grid item>
+              <YouTubeToggle youTubeId={this.props.youTubeId} />
+            </Grid>
+            {[{ name: 'Transpose', clickCallback: this.handleTransposeClick, value: transposeAmount },
+              { name: 'Column Count', clickCallback: this.handleColumnClick, value: columnCount },
+              { name: 'Font Size', clickCallback: this.handleFontClick, value: fontSize }]
+              .map(({ name, clickCallback, value }) => (
+                <div key={name} className={classes.option}>
+                  <Grid item className={classes.words}>
+                    <Badge color='primary' badgeContent={value}>
+                      <Typography variant='body1' className={classes.padding}>{name}</Typography>
+                    </Badge>
+                  </Grid>
+                  <Grid item>
+                    <Button onClick={clickCallback}>
+                      <Typography variant='body2'>{this.decrease}</Typography>
+                    </Button>
+                  </Grid>
+                  <Grid item>
+                    <Button onClick={clickCallback}>
+                      <Typography variant='body2'>{this.increase}</Typography>
+                    </Button>
+                  </Grid>
+                </div>
+              ))}
+          </div>
         </Grid>
+        <Button onClick={this.handleRightScroll} className={classes.scrollButton}>
+          <KeyboardArrowRight />
+        </Button>
       </Toolbar>
     );
   }

--- a/src/components/YouTube.js
+++ b/src/components/YouTube.js
@@ -1,4 +1,4 @@
-import IconButton from '@material-ui/core/IconButton';
+import Button from '@material-ui/core/Button';
 import PlayArrowIcon from '@material-ui/icons/PlayArrow';
 import Popper from '@material-ui/core/Popper';
 import React from 'react';
@@ -42,11 +42,11 @@ class YouTubeToggle extends React.Component {
 
     return (
       <>
-        <IconButton onClick={this.handleToggle} buttonRef={(node) => {
+        <Button onClick={this.handleToggle} buttonRef={(node) => {
           this.anchorEl = node;
         }}>
           <PlayArrowIcon />
-        </IconButton>
+        </Button>
         <Popper
           id='youtube-player'
           open={this.state.visible}


### PR DESCRIPTION
Added left and right scroll buttons on the music toolbar so that smaller screens don't look awful and will now have a way to access additional options. Buttons will only show if you can use them. Resize detected using `</ReactResizeDetector>`.

Additionally, cleaned up some places we were using `IconButton` instead of `Button` and vice-versa. Determined which one to use based on what already existed in those areas.

![small-music-toolbar](https://user-images.githubusercontent.com/5377267/56071445-66c6b000-5d43-11e9-9ecf-295645904c4e.gif)
