### PR TITLE
Fix base64 encoder to support Unicode

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "eslint-plugin-react": "^7.12.4",
     "history": "^4.9.0",
     "jquery": "^3.4.1",
+    "js-base64": "^2.5.1",
     "markdown-it": "^8.4.2",
     "markdown-it-music": "~0.0.9",
     "node-sass": "^4.11.0",

--- a/src/components/AddNewFile.js
+++ b/src/components/AddNewFile.js
@@ -51,7 +51,7 @@ class AddNewFile extends React.Component {
   handleAddNewFile = async () => {
     const { repo, branch } = this.props.match.params;
     const path = this.getNewFilePath();
-    const content = btoa(this.getTemplateContents());
+    const content = this.getTemplateContents();
 
     const response = await putContents(repo, path, content, undefined, branch);
 

--- a/src/components/MarkdownEditor.js
+++ b/src/components/MarkdownEditor.js
@@ -79,8 +79,8 @@ class MarkdownEditor extends React.Component {
 
       const { repo, path, branch } = this.props.match.params;
       const { markdown, sha } = this.state;
-      const contents = btoa(markdown);
-      const response = await putContents(repo, path, contents, sha, branch);
+      const content = markdown;
+      const response = await putContents(repo, path, content, sha, branch);
       const json = await response.json();
 
       if (response.status === 200) {
@@ -107,7 +107,7 @@ class MarkdownEditor extends React.Component {
     const json = await getContents(repo, path, branch);
     this.setState({
       isLoaded: true,
-      markdown: json.content ? atob(json.content) : '',
+      markdown: json.content,
       sha: json.sha
     });
   }

--- a/src/components/MarkdownViewer.js
+++ b/src/components/MarkdownViewer.js
@@ -34,7 +34,7 @@ class MarkdownViewer extends React.Component {
     const json = await getContents(repo, path, branch);
     this.setState({
       isLoaded: true,
-      markdown: json.content ? atob(json.content) : ''
+      markdown: json.content
     });
   }
 

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -1,3 +1,4 @@
+import { Base64 } from 'js-base64';
 import { LOCAL_STORAGE_NAMESPACE } from './constants';
 
 const GITHUB_TOKEN_LOCAL_STORAGE_KEY = `${LOCAL_STORAGE_NAMESPACE}:github_token`;
@@ -18,7 +19,9 @@ export async function getContents(repo, path, branch) {
   }
   const apiUrl = getApiUrl(`/repos/${repo}/contents/${path}`, branch);
   const response = await fetch(apiUrl, { cache: 'no-cache' });
-  return response.json();
+  const json = await response.json();
+  json.content = json.content ? Base64.decode(json.content) : '';
+  return json;
 }
 
 export async function putContents(repo, path, content, sha, branch) {
@@ -26,7 +29,7 @@ export async function putContents(repo, path, content, sha, branch) {
 
   const body = {
     message: `Music Markdown published ${path}`,
-    content: content,
+    content: Base64.encode(content),
     branch
   };
 


### PR DESCRIPTION
Saving files copied from other websites sometimes fails because they have unicode characters. This PR fixes that bug by using a base64 encoder that supports unicode.

![support-unicode](https://user-images.githubusercontent.com/361429/65821794-51f5b000-e1ef-11e9-9842-55fdeddcadb6.gif)