### PR TITLE
Bug fix: update AddNewFile button layout

### DIFF
--- a/src/components/FileView/AddNewFile.tsx
+++ b/src/components/FileView/AddNewFile.tsx
@@ -80,12 +80,7 @@ export default function AddNewFile() {
   }
 
   return (
-    <StyledGrid
-      container
-      direction="row"
-      justifyContent="flex-end"
-      alignItems="flex-end"
-    >
+    <StyledGrid item justifyContent="flex-end" alignItems="flex-end">
       <Tooltip
         title={
           gitHubToken ? "Add Song" : "Add a GitHub Token to Enable Editing"


### PR DESCRIPTION
# How to reproduce the bug

Visit https://musicmd.app/#/repos/paul-louyot/example-md-music/browser/master

The container of the button to add a new file prevents any click on the files at the bottom of the list

<img width="703" alt="Screenshot 2023-06-26 at 21 42 32" src="https://github.com/music-markdown/music-markdown/assets/44401972/1831ed5e-f129-4505-962e-43ecf6039455">

# Change

Change the parent container style from a Grid container to a Grid item