### PR TITLE
feat: add keyboard shortcuts to set columns number

### DIFF
--- a/src/components/MusicMd/View.tsx
+++ b/src/components/MusicMd/View.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import LinearProgress from "@mui/material/LinearProgress";
+import { useCallback, useEffect } from "react";
 import { useFileContent } from "../../context/GitHubApiProvider";
 import {
   useColumns,
@@ -17,9 +18,28 @@ const DivRoot = styled("div")({
 export default function View() {
   const { repo, path, branch } = useRouteParams();
   const { loading, content } = useFileContent(repo, path, branch);
-  const { columns } = useColumns();
+  const { columns, setColumns } = useColumns();
   const { transpose } = useTranspose();
   const { zoom } = useZoom();
+
+  const handleKeyPress = useCallback(
+    (event: any) => {
+      if (event.key === "F2" && columns > 1) {
+        setColumns(columns - 1);
+      }
+      if (event.key === "F3" && columns < 8) {
+        setColumns(columns + 1);
+      }
+    },
+    [columns, setColumns]
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyPress);
+    return () => {
+      document.removeEventListener("keydown", handleKeyPress);
+    };
+  }, [handleKeyPress]);
 
   if (loading) {
     return <LinearProgress />;


### PR DESCRIPTION
# Description

Enable changing the number of columns through keyboard shortcuts when viewing the content of a file.

I suggest: 
- F2 to decrease by 1 
- F3 to increase by 1

I don't know much about React and I followed [the first tutorial](https://devtrium.com/posts/how-keyboard-shortcut) on keyboard bindings I found, so I am very open to feedback :)

# Tests

Tested in dev mode on http://localhost:3000/repos/paul-louyot/music-markdown/viewer/main/La%20Foule%20-%20Edith%20Piaf?transpose=0

I looks like it is woking well only on Chrome for now:

### Chrome

https://github.com/music-markdown/music-markdown/assets/44401972/097b05d7-adc6-435d-927c-b0e6a039d847

### Firefox

The search bar shows up after pressing F3 and prevents additional column increase

https://github.com/music-markdown/music-markdown/assets/44401972/878574d2-4351-465a-90f7-570a07ff0b21

### Safari

When pressing F3 twice, the columns count increases by one only. On reload the columns count is 3

https://github.com/music-markdown/music-markdown/assets/44401972/90097341-1d5c-4a7e-8e10-bd83fad8a506

